### PR TITLE
Implement get and post requests for Flock API

### DIFF
--- a/server/models/User.js
+++ b/server/models/User.js
@@ -2,7 +2,7 @@ var mongoose = require('mongoose');
 
 var userSchema = new mongoose.Schema({
   name: String,
-  facebookId: String,
+  userId: String,
   boards: []
 });
 

--- a/server/models/User.js
+++ b/server/models/User.js
@@ -2,6 +2,7 @@ var mongoose = require('mongoose');
 
 var userSchema = new mongoose.Schema({
   name: String,
+  facebookId: String,
   boards: []
 });
 

--- a/server/server.js
+++ b/server/server.js
@@ -52,22 +52,45 @@ app.use(express.static(path.resolve(__dirname, '../public')));
 // GET REQUESTS //
 
 app.get('/', function(req, res) {
-  res.writeHead(200, {'Content-Type': 'text/html'});
 	fs.readFile(path.resolve(__dirname, '../public/index.html'), function(err, data) {
 		if (err) {
-      console.error(err);
+      throw new Error(err);
     } else {
+      res.writeHead(200, {'Content-Type': 'text/html'});
 		  res.send(data);
     }
 	});
 });
 
-app.get('/api/users/*', function(req, res) {});
-app.get('/api/boards/*', function(req, res) {});
-app.get('/api/cards/*', function(req, res) {});
+app.get('/api/users/*', function(req, res) {
+  var username = req.params[0];
+  var fbId = req.body.fbId;
+
+  return findUser({name: username})
+    .then(function (user) {
+      if (!user) {
+        throw new Error('User already exists');
+      } else {
+        res.status(200).json(user);
+      }
+    }).fail(function (err) {
+      res.status(404).json(err);
+    });
+});
+
+app.get('/api/boards/*', function(req, res) {
+  var board = req.params[0];
+  res.end();
+});
+
+app.get('/api/cards/*', function(req, res) {
+  var card = req.params[0];
+  res.end();
+});
 
 // POST REQUESTS //
-app.post('/api/users', function(req, res) {});
+
+app.post('/api/users', function(req, res, next) {});
 app.post('/api/boards', function(req, res) {});
 app.post('/api/cards', function(req, res) {});
 

--- a/server/server.js
+++ b/server/server.js
@@ -51,13 +51,22 @@ app.use(express.static(path.resolve(__dirname, '../public')));
 
 // GET REQUESTS //
 
-app.get('/', function(req, res) {});
+app.get('/', function(req, res) {
+  res.writeHead(200, {'Content-Type': 'text/html'});
+	fs.readFile(path.resolve(__dirname, '../public/index.html'), function(err, data) {
+		if (err) {
+      console.error(err);
+    } else {
+		  res.send(data);
+    }
+	});
+});
+
 app.get('/api/users/*', function(req, res) {});
 app.get('/api/boards/*', function(req, res) {});
 app.get('/api/cards/*', function(req, res) {});
 
 // POST REQUESTS //
-
 app.post('/api/users', function(req, res) {});
 app.post('/api/boards', function(req, res) {});
 app.post('/api/cards', function(req, res) {});

--- a/server/server.js
+++ b/server/server.js
@@ -96,7 +96,18 @@ app.get('/api/boards/*', function(req, res) {
 
 app.get('/api/cards/*', function(req, res) {
   var card = req.params[0];
-  res.end();
+  var cardId = req.body.cardId;
+
+  return findBoard({cardId: cardId})
+    .then(function (card) {
+      if (!card) {
+        throw new Error('Card: %s does not exist', card);
+      } else {
+        res.status(200).json(card);
+      }
+    }).fail(function (err) {
+      res.status(404).json(err);
+    });
 });
 
 // POST REQUESTS //

--- a/server/server.js
+++ b/server/server.js
@@ -1,29 +1,55 @@
 var express = require('express');
-var mongoose = require('mongoose');
 var path = require('path');
 var fs = require('fs');
+Q = require('q');
+var mongoose = require('mongoose');
 
 var webpack = require('webpack');
 var WebpackDevServer = require('webpack-dev-server');
 var config = require('../webpack.config.js');
 
-var app = express();
-mongoose.connect('mongodb://localhost/flock');
-app.use(express.static(path.resolve(__dirname, '../public')));
+/* -------------- */
+/*     MODELS     */
+/* -------------- */
 
-app.get('/', function(request, response) {
-  response.writeHead(200, {'Content-Type': 'text/html'});
-	fs.readFile(path.resolve(__dirname, '../public/index.html'), function(err, data) {
-		if (err) {
-      console.error(err);
-    } else {
-		  response.send(data);
-    }
-	});
+var User = require('./models/User');
+var Board = require('./models/Board');
+var Card = require('./models/BoardCard');
+
+/* ---------------- */
+/*     PROMISES     */
+/* ---------------- */
+
+var findUser = Q.nbind(User.findOne, User);
+var createUser = Q.nbind(User.create, User);
+var findBoard = Q.nbind(Board.findOne, Board);
+var createBoard = Q.nbind(Board.create, Board);
+var findCard = Q.nbind(Card.findOne, Card);
+var createCard = Q.nbind(Card.create, Card);
+
+/* ---------------- */
+/*     DATABASE     */
+/* ---------------- */
+
+mongoose.connect('mongodb://localhost/flock');
+var db = mongoose.connection;
+
+db.on('error', function() {
+	console.error.bind(console, 'Connection Error:');
 });
 
-app.listen(3000);
+db.once('open', function() {
+	console.log('MongoDB is open');
+});
 
+var app = express();
+app.use(express.static(path.resolve(__dirname, '../public')));
+
+/* --------------- */
+/*     SERVERS     */
+/* --------------- */
+
+app.listen(3000);
 new WebpackDevServer(webpack(config), {
   hot: true,
   historyApiFallback: true,

--- a/server/server.js
+++ b/server/server.js
@@ -45,6 +45,34 @@ db.once('open', function() {
 var app = express();
 app.use(express.static(path.resolve(__dirname, '../public')));
 
+/* ----------- */
+/*     API     */
+/* ----------- */
+
+// GET REQUESTS //
+
+app.get('/', function(req, res) {});
+app.get('/api/users/*', function(req, res) {});
+app.get('/api/boards/*', function(req, res) {});
+app.get('/api/cards/*', function(req, res) {});
+
+// POST REQUESTS //
+
+app.post('/api/users', function(req, res) {});
+app.post('/api/boards', function(req, res) {});
+app.post('/api/cards', function(req, res) {});
+
+// PUT REQUESTS //
+app.put('/api/users/*', function(req, res) {});
+app.put('/api/boards/*', function(req, res) {});
+app.put('/api/cards/*', function(req, res) {});
+
+// DELETE REQUESTS //
+app.delete('/api/users/*', function(req, res) {});
+app.delete('/api/boards/*', function(req, res) {});
+app.delete('/api/cards/*', function(req, res) {});
+
+
 /* --------------- */
 /*     SERVERS     */
 /* --------------- */

--- a/server/server.js
+++ b/server/server.js
@@ -68,7 +68,7 @@ app.get('/api/users/*', function(req, res) {
   var name = req.params[0];
   var uid = req.body.uid;
 
-  return findUser({name: name})
+  return findUser({userId: uid})
     .then(function (user) {
       if (!user) {
         throw new Error('User: %s does not exist', username);
@@ -80,11 +80,11 @@ app.get('/api/users/*', function(req, res) {
     });
 });
 
-app.get('/api/boards/*', function(req, res) {
-  var board = req.params[0];
-  var boardId = req.body.boardId;
+app.get('/api/boards', function(req, res) {
+  var board = req.body.board;
+  var uid = req.body.uid;
 
-  return findBoard({boardId: boardId})
+  return findBoard({title: board, userId: uid})
     .then(function (board) {
       if (!board) {
         throw new Error('Board: %s does not exist', board);
@@ -96,8 +96,8 @@ app.get('/api/boards/*', function(req, res) {
     });
 });
 
-app.get('/api/cards/*', function(req, res) {
-  var card = req.params[0];
+app.get('/api/cards', function(req, res) {
+  var title = req.body.title;
   var cardId = req.body.cardId;
 
   return findBoard({cardId: cardId})
@@ -117,7 +117,6 @@ app.get('/api/cards/*', function(req, res) {
 app.post('/api/users', function(req, res, next) {
   var username = req.body.username;
   var uid = req.body.uid;
-  var board = req.body.board ? [req.body.board] : [];
 
   findUser({userId: uid})
     .then(function (user) {
@@ -127,7 +126,7 @@ app.post('/api/users', function(req, res, next) {
         return createUser({
           name: username,
           uid: uid,
-          boards: board
+          boards: []
         });
       }
     }).then(function (user) {
@@ -144,6 +143,7 @@ app.post('/api/boards', function(req, res) {
   var uid = req.body.uid;
   var boards = req.body.boards;
 
+  // perhaps this should happen client side
   boards.forEach(function (board) {
     if (board.title === title) {
       throw new Error('Board already exists');
@@ -180,7 +180,7 @@ app.post('/api/cards', function(req, res) {
   findCard({venueId: venue})
     .then(function (card) {
       if (card) {
-        throw new Error('Card already exists');
+        res.status(200, card);
       }
     })
     .catch(function (err) {

--- a/server/server.js
+++ b/server/server.js
@@ -69,7 +69,7 @@ app.get('/api/users/*', function(req, res) {
   return findUser({name: username})
     .then(function (user) {
       if (!user) {
-        throw new Error('User already exists');
+        throw new Error('User: %s does not exist', username);
       } else {
         res.status(200).json(user);
       }
@@ -80,7 +80,18 @@ app.get('/api/users/*', function(req, res) {
 
 app.get('/api/boards/*', function(req, res) {
   var board = req.params[0];
-  res.end();
+  var boardId = req.body.boardId;
+
+  return findBoard({boardId: boardId})
+    .then(function (board) {
+      if (!board) {
+        throw new Error('Board: %s does not exist', board);
+      } else {
+        res.status(200).json(board);
+      }
+    }).fail(function (err) {
+      res.status(404).json(err);
+    });
 });
 
 app.get('/api/cards/*', function(req, res) {
@@ -89,7 +100,6 @@ app.get('/api/cards/*', function(req, res) {
 });
 
 // POST REQUESTS //
-
 app.post('/api/users', function(req, res, next) {});
 app.post('/api/boards', function(req, res) {});
 app.post('/api/cards', function(req, res) {});

--- a/server/server.js
+++ b/server/server.js
@@ -119,7 +119,7 @@ app.post('/api/users', function(req, res, next) {
   var uid = req.body.uid;
   var board = req.body.board ? [req.body.board] : [];
 
-  findUser({uid: uid})
+  findUser({userId: uid})
     .then(function (user) {
       if (user) {
         throw new Error('User already exists');
@@ -149,7 +149,6 @@ app.post('/api/boards', function(req, res) {
       throw new Error('Board already exists');
     }
   });
-
   boards.push({
     title: title,
     headerImage: img,
@@ -160,16 +159,47 @@ app.post('/api/boards', function(req, res) {
 
   return updateUser({userId: uid},
     {boards: boards})
-    .then(function (err, board) {
-      if (err) {
-        throw new Error('Could not update user boards');
+    .then(function (user) {
+      if (user) {
+        res.json(200, user.boards);
       } else {
-        res.json(200, board);
+        throw new Error('User not found');
       }
+    })
+    .fail(function (err) {
+      throw new Error('Could not update user boards');
     });
 });
 
-app.post('/api/cards', function(req, res) {});
+app.post('/api/cards', function(req, res) {
+  var title = req.body.title;
+  var desc = req.body.desc;
+  var venue = req.body.venue;
+  var board = req.body.board;
+
+  findCard({venueId: venue})
+    .then(function (card) {
+      if (card) {
+        throw new Error('Card already exists');
+      }
+    })
+    .catch(function (err) {
+      return createCard({
+        userTitle: title,
+        description: desc,
+        venueId: venue,
+        createdAt: new Date()
+      })
+      .then(function (card) {
+        if (card) {
+          res.status(201).json(card);
+        }
+      })
+      .fail(function (err) {
+        throw new Error('Failed to create card');
+      });
+    });
+});
 
 // PUT REQUESTS //
 app.put('/api/users/*', function(req, res) {});


### PR DESCRIPTION
`GET "/"`
- index.html is returned

`GET "/api/users/:username"`
- takes in user name as a URL parameter but preferably it should be userId which would mean userIds should be stored in user card views; this is only important for when you want to visit a friend's page but otherwise not MVP
- returns user object

`GET "/api/boards"`
- takes in board title and user (social authentication) ID
- retrieves board object if it exists

`GET "/api/cards"`
- takes in card title and card ID
- returns card object if it exists

`POST "/api/users"`
- takes in username, user ID
- creates a new user with an empty array of boards
- returns new user

`POST "/api/boards"`
- takes in board data: title, image, description
- also takes in user ID and user's current boards (from App state)
- checks boards to see if new board already exists but this check should be refactored and moved into client side
- if new board is able to be pushed into current array of boards on the client side, it will be more enjoyable for user who doesn't have to wait for an API request that might result in a duplication error that could have been handled client side (we assume user's current "boards" state is always up to date with user's boards in the database)
- then, this post request can simply take the new boards array and simply update the user's boards field if there are no errors

`POST "/api/cards"`
- takes card data and searches database using venue ID
- if card exists, cannot make a new one but return the card that was found
- if card does not exist, create new one using passed in data
- return new card when created successfully
